### PR TITLE
chore: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: build test clean run
+
+BINARY_NAME=gbot
+
+build:
+	go build -o $(BINARY_NAME) -v
+
+test:
+	go test -v ./...
+
+clean:
+	go clean
+	rm -f $(BINARY_NAME)
+
+run:
+	go run main.go
+
+deps:
+	go mod download
+
+lint:
+	golangci-lint run


### PR DESCRIPTION
Add Makefile with common build, test, and run targets.

*Dummy PR - December 2025*
<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Add Makefile to standardize build, test, and development workflows for the gbot Go application.
Main changes:
- Added build target to compile Go binary with verbose output into executable named gbot
- Added test target to run all project tests with verbose output across all packages
- Added clean, run, deps, and lint targets for dependency management and code quality checks
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
