### PR TITLE
chore: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o gbot .
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+COPY --from=builder /app/gbot .
+
+CMD ["./gbot"]


### PR DESCRIPTION
Add multi-stage Dockerfile for containerized builds.

*Dummy PR - December 2025*
<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Add Dockerfile to containerize Go application using multi-stage build for optimized production image size and deployment efficiency.
Main changes:
- Implemented multi-stage Dockerfile with Go 1.21 builder stage for compilation and minimal Alpine base for runtime
- Configured CGO_ENABLED=0 and GOOS=linux build flags to ensure static binary compatibility across Linux environments
- Added ca-certificates in final stage to enable HTTPS connectivity for containerized application
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
